### PR TITLE
Adding various sprite update blocks

### DIFF
--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -299,7 +299,6 @@ namespace spriteutils {
     //% draggableParameters=reporter
     //% target.shadow=variables_get
     //% target.defl=mySprite
-
     //% group=Sprite
     //% weight=5
     export function onSpriteUpdate(target: Sprite, callback: (sprite: Sprite) => void) {
@@ -325,7 +324,7 @@ namespace spriteutils {
     //% interval.shadow=timePicker
     //% interval.defl=500
     //% group=Sprite
-    //% weight=5
+    //% weight=4
     export function onSpriteUpdateInterval(target: Sprite, interval: number, callback?: (sprite: Sprite) => void) {
         state().updatingSprites.push(new SpriteUpdateHandler(target, callback, Math.max(interval || 0, 0)))
     }
@@ -337,7 +336,7 @@ namespace spriteutils {
     //% interval.shadow=timePicker
     //% interval.defl=500
     //% group=Sprite
-    //% weight=10
+    //% weight=9
     export function onSpriteKindUpdateInterval(kind: number, interval: number, callback: (sprite: Sprite) => void) {
         state().updatingKinds.push(new SpriteKindUpdateHandler(kind, callback, Math.max(interval || 0, 0)))
     }

--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -68,6 +68,110 @@ namespace spriteutils {
         After
     }
 
+    let stateStack: SpriteUtilState[];
+
+    class SpriteUpdateHandler {
+        timer: number;
+        constructor(
+            public sprite: Sprite,
+            public update: (sprite: Sprite) => void,
+            public interval: number
+        ) {
+            this.timer = 0;
+        }
+    }
+
+    class SpriteKindUpdateHandler {
+        timer: number
+        constructor(
+            public kind: number,
+            public update: (sprite: Sprite) => void,
+            public interval: number
+        ) {
+            this.timer = 0;
+        }
+    }
+
+    class SpriteUtilState {
+        updatingKinds: SpriteKindUpdateHandler[];
+        updatingSprites: SpriteUpdateHandler[];
+
+        constructor() {
+            this.updatingSprites = [];
+            this.updatingKinds = [];
+
+            game.currentScene().eventContext.registerFrameHandler(scene.UPDATE_PRIORITY + 1, () => {
+                this.updateSprites(game.currentScene().eventContext.deltaTimeMillis);
+                this.updateSpriteKinds(game.currentScene().eventContext.deltaTimeMillis);
+            });
+        }
+
+        protected updateSprites(dtMillis: number) {
+            let cleanupDestroyed = false;
+            for (const handler of this.updatingSprites) {
+                if (handler.sprite.flags & sprites.Flag.Destroyed) {
+                    cleanupDestroyed = true;
+                    continue;
+                }
+
+                if (handler.interval) {
+                    handler.timer -= dtMillis;
+                    while (handler.timer <= 0) {
+                        handler.timer += handler.interval;
+                        handler.update(handler.sprite);
+                    }
+                }
+                else {
+                    handler.update(handler.sprite);
+                }
+            }
+
+            if (cleanupDestroyed) {
+                this.updatingSprites = this.updatingSprites.filter(handler => !(handler.sprite.flags & sprites.Flag.Destroyed))
+            }
+        }
+
+        protected updateSpriteKinds(dtMillis: number) {
+            for (const handler of this.updatingKinds) {
+                if (handler.interval) {
+                    handler.timer -= dtMillis;
+                    while (handler.timer <= 0) {
+                        handler.timer += handler.interval;
+                        for (const sprite of sprites.allOfKind(handler.kind)) {
+                            handler.update(sprite);
+                        }
+                    }
+                }
+                else {
+                    for (const sprite of sprites.allOfKind(handler.kind)) {
+                        handler.update(sprite);
+                    }
+                }
+
+            }
+        }
+    }
+
+    function init() {
+        if (stateStack) return;
+
+        stateStack = [new SpriteUtilState()];
+
+        game.addScenePushHandler(() => {
+            stateStack.push(new SpriteUtilState());
+        });
+
+        game.addScenePopHandler(() => {
+            stateStack.pop();
+            if (stateStack.length === 0) stateStack.push(new SpriteUtilState());
+        });
+    }
+
+    function state() {
+        init();
+        return stateStack[stateStack.length - 1];
+    }
+
     /**
      * Returns true if the given sprite does not exist,
      * or is destroyed, and false otherwise.
@@ -187,6 +291,55 @@ namespace spriteutils {
             Math.cos(angleInRadians) * speed,
             Math.sin(angleInRadians) * speed
         );
+    }
+
+    //% blockId=spriteutilonspriteupdate
+    //% block="on $target update $sprite"
+    //% handlerStatement
+    //% draggableParameters=reporter
+    //% target.shadow=variables_get
+    //% target.defl=mySprite
+
+    //% group=Sprite
+    //% weight=5
+    export function onSpriteUpdate(target: Sprite, callback: (sprite: Sprite) => void) {
+        state().updatingSprites.push(new SpriteUpdateHandler(target, callback, 0))
+    }
+
+    //% blockId=spriteutilonspritekindupdate
+    //% block="on $sprite of kind $kind update"
+    //% draggableParameters=reporter
+    //% kind.shadow=spritekind
+    //% group=Sprite
+    //% weight=10
+    export function onSpriteKindUpdate(kind: number, callback: (sprite: Sprite) => void) {
+        state().updatingKinds.push(new SpriteKindUpdateHandler(kind, callback, 0))
+    }
+
+    //% blockId=spriteutilonspriteupdateinterval
+    //% block="on $target update $sprite every $interval ms"
+    //% handlerStatement
+    //% draggableParameters=reporter
+    //% target.shadow=variables_get
+    //% target.defl=mySprite
+    //% interval.shadow=timePicker
+    //% interval.defl=500
+    //% group=Sprite
+    //% weight=5
+    export function onSpriteUpdateInterval(target: Sprite, interval: number, callback?: (sprite: Sprite) => void) {
+        state().updatingSprites.push(new SpriteUpdateHandler(target, callback, Math.max(interval || 0, 0)))
+    }
+
+    //% blockId=spriteutilonspritekindupdateinterval
+    //% block="on $sprite of kind $kind update every $interval ms"
+    //% draggableParameters=reporter
+    //% kind.shadow=spritekind
+    //% interval.shadow=timePicker
+    //% interval.defl=500
+    //% group=Sprite
+    //% weight=10
+    export function onSpriteKindUpdateInterval(kind: number, interval: number, callback: (sprite: Sprite) => void) {
+        state().updatingKinds.push(new SpriteKindUpdateHandler(kind, callback, Math.max(interval || 0, 0)))
     }
 
     /**

--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -293,24 +293,10 @@ namespace spriteutils {
         );
     }
 
-    //% blockId=spriteutilonspriteupdate
-    //% block="on $target update $sprite"
-    //% handlerStatement
-    //% draggableParameters=reporter
-    //% target.shadow=variables_get
-    //% target.defl=mySprite
-    //% group=Sprite
-    //% weight=5
     export function onSpriteUpdate(target: Sprite, callback: (sprite: Sprite) => void) {
         state().updatingSprites.push(new SpriteUpdateHandler(target, callback, 0))
     }
 
-    //% blockId=spriteutilonspritekindupdate
-    //% block="on $sprite of kind $kind update"
-    //% draggableParameters=reporter
-    //% kind.shadow=spritekind
-    //% group=Sprite
-    //% weight=10
     export function onSpriteKindUpdate(kind: number, callback: (sprite: Sprite) => void) {
         state().updatingKinds.push(new SpriteKindUpdateHandler(kind, callback, 0))
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13754588/181810858-974522e5-fdbf-4036-ad77-988464536bfe.png)


I was making a Zelda like game and wanted to add enemy AI, and realized there isn't an easy way to do that right now. I don't know if we need *all* of these block, but they do all have their uses...

The SpriteKind blocks are the most obvious and match our current blocks, but they can also be replicated by using a for-of loop, game-update, and all-sprites-of-kind (which is a lot). They also aren't quite as modular.

The single Sprite blocks read a little weirder (sprite is in there twice) but enable you to do things like making a function that adds a particular ai to a Sprite. That's a more advanced scenario for sure but it does significantly reduce the amount of code duplication if you have, say, two different kinds of Koopas with different SpriteKinds


Also, ideally this would just be two blocks with the intervals being optional arguments but TIL we don't support that for event blocks because we require the callback to be the final argument to the function.