### PR TITLE
cancel move operation after another move starts

### DIFF
--- a/docs/move-to-at-speed.md
+++ b/docs/move-to-at-speed.md
@@ -3,3 +3,5 @@
 Moves a sprite to the given location over a given period of time.
 The location can be either a sprite, position, or tile location.
 If the target location is a moving sprite, the sprite will move to its location at the time this function is called.
+Only works with sprites that have no acceleration or friction.
+Manually changing the sprite's velocity while it's moving will cancel the move.

--- a/docs/move-to.md
+++ b/docs/move-to.md
@@ -3,3 +3,5 @@
 Moves a sprite to the given location over a given amount of time.
 The location can be either a sprite, position, or tile location.
 If the target location is a moving sprite, the sprite will move to its location at the time this function is called.
+Only works with sprites that have no acceleration or friction.
+Manually changing the sprite's velocity while it's moving will cancel the move.

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "arcade-sprite-util",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "",
     "dependencies": {
         "device": "*"

--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -237,7 +237,10 @@ namespace spriteutils {
      * Moves a sprite to the given location over a given amount of time.
      * The location can be either a sprite, position, or tile location.
      * If the target location is a moving sprite, the sprite will move
-     * to its location at the time this function is called
+     * to its location at the time this function is called. Only works
+     * with sprites that have no acceleration or friction. Manually
+     * changing the sprite's velocity while it's moving will cancel
+     * the move.
      */
     //% blockId=spriteutilmoveto
     //% block="$sprite move to $location over $time ms||and pause $doPause"
@@ -258,7 +261,10 @@ namespace spriteutils {
      * Moves a sprite to the given location at a given speed.
      * The location can be either a sprite, position, or tile location.
      * If the target location is a moving sprite, the sprite will move
-     * to its location at the time this function is called
+     * to its location at the time this function is called. Only works
+     * with sprites that have no acceleration or friction. Manually
+     * changing the sprite's velocity while it's moving will cancel
+     * the move.
      */
     //% blockId=spriteutilmovetoatspeed
     //% block="$sprite move to $location at speed $speed||and pause $doPause"
@@ -278,19 +284,35 @@ namespace spriteutils {
         const x = location.x;
         const y = location.y;
 
+        const vx = sprite._vx;
+        const vy = sprite._vy;
+
+        // Store the current game time in the sprite's data.
+        // If this function is called again on this sprite before the
+        // move operation is completed, we want to skip the part where
+        // we clear the velocity and snap the sprite to the destination.
+        const moveTime = game.runtime();
+        const prop = "$__currentMoveTime";
+
+        sprite.data[prop] = moveTime;
+
         if (doPause) {
             pause(time);
-            sprite.vx = 0;
-            sprite.vy = 0;
-            sprite.x = x;
-            sprite.y = y;
-        }
-        else {
-            setTimeout(() => {
+            if (sprite.data[prop] === moveTime && sprite._vx === vx && sprite._vy === vy) {
                 sprite.vx = 0;
                 sprite.vy = 0;
                 sprite.x = x;
                 sprite.y = y;
+            }
+        }
+        else {
+            setTimeout(() => {
+                if (sprite.data[prop] === moveTime && sprite._vx === vx && sprite._vy === vy) {
+                    sprite.vx = 0;
+                    sprite.vy = 0;
+                    sprite.x = x;
+                    sprite.y = y;
+                }
             }, time);
         }
     }

--- a/test.ts
+++ b/test.ts
@@ -8,40 +8,40 @@ let d = 0
 let myEnemy: Sprite = null
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . 4 4 . . . . . . . . 
-    . . . . 4 4 . . 4 4 . . . . . . 
-    . . . 4 . 4 . . . . 4 . . . . . 
-    . . 4 . 4 4 . . . . . 4 . . . . 
-    . . 4 . 4 . . . . . . 4 . . . . 
-    . 4 . . 4 . . . . . . 4 . . . . 
-    . 4 . . 4 . . . . . . 4 . . . . 
-    . . . . 4 . . . . . 4 . . . . . 
-    . . . . . 4 4 . 4 4 4 . . . . . 
-    . . . . . . 4 4 4 . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . 4 4 . . . . . . . .
+    . . . . 4 4 . . 4 4 . . . . . .
+    . . . 4 . 4 . . . . 4 . . . . .
+    . . 4 . 4 4 . . . . . 4 . . . .
+    . . 4 . 4 . . . . . . 4 . . . .
+    . 4 . . 4 . . . . . . 4 . . . .
+    . 4 . . 4 . . . . . . 4 . . . .
+    . . . . 4 . . . . . 4 . . . . .
+    . . . . . 4 4 . 4 4 4 . . . . .
+    . . . . . . 4 4 4 . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
     `, SpriteKind.Player)
 myEnemy = sprites.create(img`
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . 3 3 . . . . . . . . 
-    . . . . 3 3 . . 3 3 . . . . . . 
-    . . . 3 . 3 . . . . 3 . . . . . 
-    . . 3 . 3 3 . . . . . 3 . . . . 
-    . . 3 . 3 . . . . . . 3 . . . . 
-    . 3 . . 3 . . . . . . 3 . . . . 
-    . 3 . . 3 . . . . . . 3 . . . . 
-    . . . . 3 . . . . . 3 . . . . . 
-    . . . . . 3 3 . 3 3 3 . . . . . 
-    . . . . . . 3 3 3 . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
-    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . 3 3 . . . . . . . .
+    . . . . 3 3 . . 3 3 . . . . . .
+    . . . 3 . 3 . . . . 3 . . . . .
+    . . 3 . 3 3 . . . . . 3 . . . .
+    . . 3 . 3 . . . . . . 3 . . . .
+    . 3 . . 3 . . . . . . 3 . . . .
+    . 3 . . 3 . . . . . . 3 . . . .
+    . . . . 3 . . . . . 3 . . . . .
+    . . . . . 3 3 . 3 3 3 . . . . .
+    . . . . . . 3 3 3 . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
     `, SpriteKind.Player)
 myEnemy.setPosition(156, 112)
 
@@ -89,4 +89,29 @@ testRoundWPrecision(3.1, 15, "3.100000000000000");
 controller.B.onEvent(ControllerButtonEvent.Pressed, () => {
     consoleVisible = !consoleVisible;
     game.consoleOverlay.setVisible(consoleVisible)
+})
+
+let pIndex = 1;
+const positions = [
+    spriteutils.pos(0, 0),
+    spriteutils.pos(160, 0),
+    spriteutils.pos(160, 120),
+    spriteutils.pos(0, 120),
+];
+
+let moveSprite = sprites.create(img`
+3 3 3 3
+3 3 3 3
+3 3 3 3
+3 3 3 3
+`)
+
+spriteutils.moveTo(moveSprite, positions[0], 1000)
+
+controller.up.onEvent(ControllerButtonEvent.Pressed, () => {
+    spriteutils.moveTo(moveSprite, positions[pIndex++ % positions.length], 1000)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, () => {
+    moveSprite.vx = 5
+    moveSprite.vy = 5
 })


### PR DESCRIPTION
If you call one of the two move functions, currently they will always snap to the final position after the allotted time has passed. Adding a check to see if another move operation has been started in the meantime or the user changed the velocity manually so that we can disable that snap.