### PR TITLE
add sprite transform block

### DIFF
--- a/docs/transform-sprite-image.md
+++ b/docs/transform-sprite-image.md
@@ -1,0 +1,8 @@
+# transform sprite image
+
+Flip or rotate a Sprite's image.
+
+```blocks
+let mySprite: Sprite = null;
+spriteutils.transformSpriteImage(mySprite, spriteutils.ImageTransform.FlipHorizontal)
+```

--- a/pxt.json
+++ b/pxt.json
@@ -33,7 +33,8 @@
         "docs/consts.md",
         "docs/null-consts.md",
         "docs/on-sprite-update-interval.md",
-        "docs/on-sprite-kind-update-interval.md"
+        "docs/on-sprite-kind-update-interval.md",
+        "docs/transform-sprite-image.md"
     ],
     "testFiles": [
         "test.ts"

--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -68,6 +68,19 @@ namespace spriteutils {
         After
     }
 
+    export enum ImageTransform {
+        //% block="flip horizontal"
+        FlipHorizontal,
+        //% block="flip vertical"
+        FlipVertical,
+        //% block="rotate 90 degrees clockwise"
+        Rotate90CW,
+        //% block="rotate 180 degrees clockwise"
+        Rotate180CW,
+        //% block="rotate 270 degrees clockwise"
+        Rotate270CW
+    }
+
     let stateStack: SpriteUtilState[];
 
     class SpriteUpdateHandler {
@@ -705,6 +718,35 @@ namespace spriteutils {
 
     export class Position {
         constructor(public x: number, public y: number) {
+        }
+    }
+
+    //% blockId=spriteutiltransformspriteimage
+    //% block="apply $transform to $sprite image"
+    //% group=Sprite
+    //% weight=40
+    //% help=github:arcade-sprite-util/docs/transform-sprite-image
+    export function transformSpriteImage(sprite: Sprite, transform: ImageTransform) {
+        if (!sprite || !sprite.image) {
+            return;
+        }
+
+        switch (transform) {
+            case ImageTransform.FlipHorizontal:
+                sprite.image.flipX();
+                break;
+            case ImageTransform.FlipVertical:
+                sprite.image.flipY();
+                break;
+            case ImageTransform.Rotate90CW:
+                sprite.setImage(sprite.image.rotated(90))
+                break;
+            case ImageTransform.Rotate180CW:
+                sprite.setImage(sprite.image.rotated(180))
+                break;
+            case ImageTransform.Rotate270CW:
+                sprite.setImage(sprite.image.rotated(270))
+                break;
         }
     }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2379

adds a new block for transforming a sprite's image (basic rotations, flipping). didn't seem useful enough to be in the default toolbox, but i think sprite utils is a good fit.