### PR TITLE
use util.Point instead of Position

### DIFF
--- a/docs/point.md
+++ b/docs/point.md
@@ -1,0 +1,3 @@
+# Create point
+
+Creates a point object suitable for using with other blocks from this extension.

--- a/pxt.json
+++ b/pxt.json
@@ -3,7 +3,8 @@
     "version": "0.5.0",
     "description": "",
     "dependencies": {
-        "device": "*"
+        "device": "*",
+        "arcade-extension-utils": "github:riknoll/arcade-extension-utils#v0.1.0"
     },
     "files": [
         "README.md",
@@ -29,6 +30,7 @@
         "docs/move-to.md",
         "docs/move-to-at-speed.md",
         "docs/pos.md",
+        "docs/point.md",
         "docs/jump-impulse.md",
         "docs/consts.md",
         "docs/null-consts.md",

--- a/spriteutils.ts
+++ b/spriteutils.ts
@@ -213,7 +213,7 @@ namespace spriteutils {
     //% b.defl=myEnemy
     //% weight=90
     //% group=Sprite
-    export function distanceBetween(a: Sprite | tiles.Location | Position, b: Sprite | tiles.Location | Position): number {
+    export function distanceBetween(a: Sprite | tiles.Location | util.Point, b: Sprite | tiles.Location | util.Point): number {
         if (!a || !b) return 0;
         return Math.sqrt(((a.x - b.x) ** 2) + ((a.y - b.y) ** 2));
     }
@@ -248,7 +248,7 @@ namespace spriteutils {
 
     /**
      * Moves a sprite to the given location over a given amount of time.
-     * The location can be either a sprite, position, or tile location.
+     * The location can be either a sprite, point, or tile location.
      * If the target location is a moving sprite, the sprite will move
      * to its location at the time this function is called. Only works
      * with sprites that have no acceleration or friction. Manually
@@ -260,19 +260,19 @@ namespace spriteutils {
     //% help=github:arcade-sprite-util/docs/move-to
     //% sprite.shadow=variables_get
     //% sprite.defl=mySprite
-    //% location.shadow=spriteutilpos
+    //% location.shadow=spriteutilpoint
     //% time.shadow=timePicker
     //% time.defl=100
     //% inlineInputMode=inline
     //% weight=55
     //% group=Sprite
-    export function moveTo(sprite: Sprite, location: Sprite | tiles.Location | Position, time: number, doPause = false) {
+    export function moveTo(sprite: Sprite, location: Sprite | tiles.Location | util.Point, time: number, doPause = false) {
         moveToAtSpeed(sprite, location, distanceBetween(sprite, location) / (time / 1000), doPause);
     }
 
     /**
      * Moves a sprite to the given location at a given speed.
-     * The location can be either a sprite, position, or tile location.
+     * The location can be either a sprite, point, or tile location.
      * If the target location is a moving sprite, the sprite will move
      * to its location at the time this function is called. Only works
      * with sprites that have no acceleration or friction. Manually
@@ -285,11 +285,11 @@ namespace spriteutils {
     //% sprite.shadow=variables_get
     //% sprite.defl=mySprite
     //% speed.defl=100
-    //% location.shadow=spriteutilpos
+    //% location.shadow=spriteutilpoint
     //% inlineInputMode=inline
     //% weight=53
     //% group=Sprite
-    export function moveToAtSpeed(sprite: Sprite, location: Sprite | tiles.Location | Position, speed: number, doPause = false) {
+    export function moveToAtSpeed(sprite: Sprite, location: Sprite | tiles.Location | util.Point, speed: number, doPause = false) {
         setVelocityAtAngle(sprite, angleFrom(sprite, location), speed);
 
         const time = 1000 * (distanceBetween(sprite, location) / speed);
@@ -341,7 +341,7 @@ namespace spriteutils {
     //% sprite.defl=mySprite
     //% weight=85
     //% group=Sprite
-    export function getSpritesWithin(kind: number, distance: number, sprite: Sprite | tiles.Location | Position): Sprite[] {
+    export function getSpritesWithin(kind: number, distance: number, sprite: Sprite | tiles.Location | util.Point): Sprite[] {
         let allSprites = sprites.allOfKind(kind);
         let numItems = 0;
         let sortArray = allSprites.filter(function(value: Sprite, index: number) {
@@ -368,7 +368,7 @@ namespace spriteutils {
     //% b.defl=myEnemy
     //% weight=80
     //% group=Sprite
-    export function angleFrom(a: Sprite | tiles.Location | Position, b: Sprite | tiles.Location | Position): number {
+    export function angleFrom(a: Sprite | tiles.Location | util.Point, b: Sprite | tiles.Location | util.Point): number {
         if (!a || !b) return 0;
         return Math.atan2(
             b.y - a.y,
@@ -389,7 +389,7 @@ namespace spriteutils {
     //% spriteToMove.defl=myEnemy
     //% weight=70
     //% group=Sprite
-    export function placeAngleFrom(spriteToMove: Sprite, angleInRadians: number, distance: number, fromSprite: Sprite | tiles.Location | Position) {
+    export function placeAngleFrom(spriteToMove: Sprite, angleInRadians: number, distance: number, fromSprite: Sprite | tiles.Location | util.Point) {
         if (!fromSprite || !spriteToMove)
             return;
 
@@ -707,17 +707,32 @@ namespace spriteutils {
         }
     }
 
+    /**
+     * Deprecated. Use point() instead.
+     */
     //% blockId=spriteutilpos
     //% block="x $x y $y"
     //% help=github:arcade-sprite-util/docs/pos
     //% weight=1
     //% group=General
-    export function pos(x: number, y: number) {
+    //% deprecated
+    export function pos(x: number, y: number): Position {
         return new Position(x, y);
     }
 
-    export class Position {
-        constructor(public x: number, public y: number) {
+    //% blockId=spriteutilpoint
+    //% block="x $x y $y"
+    //% help=github:arcade-sprite-util/docs/pos
+    //% weight=1
+    //% group=General
+    export function point(x: number, y: number): util.Point {
+        return new util.Point(x, y);
+    }
+
+    // deprecated. Use util.Point instead.
+    export class Position extends util.Point {
+        constructor(x: number, y: number) {
+            super(x, y);
         }
     }
 


### PR DESCRIPTION
adds a dependency on the new point implementation in https://github.com/riknoll/arcade-extension-utils so as to be compatible with the point classes in my other extensions.

in order to maintain backwards compatibility, i left the Position class and its create function. the Position class now extends util.Point so it should be compatible with all of the other APIs

in the unlikely case that someone updates their extension version in an existing project, there might be some weird type inference edge cases if they mix the old and new blocks but i think it's probably fine.